### PR TITLE
Issue #69: QA Part 1

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -30,8 +30,7 @@ const Amount = ({ goToStep, isActive }: { goToStep?: any; isActive?: any }) => {
     }
   }, [isActive]);
 
-  const handleAmount = async (data: any): Promise<void> => {
-    console.log({ amount });
+  const handleAmount = (data: any) => {
     setAmount(data.amount);
     goToStep(1);
   };

--- a/components/OnramperWidget.js
+++ b/components/OnramperWidget.js
@@ -15,11 +15,10 @@ const OnramperWidget = () => {
 
   useEffect(() => {
     if (!address || !router.query || onramperUrl) return;
-    const network = router.query.network || "POLYGON";
+    const network = "POLYGON";
     const params = {
       apiKey: process.env.ONRAMPER_API_KEY,
-      onlyCryptos: router.query.currency || "USDC_POLYGON",
-      onlyNetwork: network,
+      onlyCryptoNetworks: network,
       isAddressEditable: false,
       wallets: `${network}:${address}`,
     };

--- a/components/SendForm.tsx
+++ b/components/SendForm.tsx
@@ -222,7 +222,7 @@ const SendForm: React.FC<SendFormProps> = ({ goToStep }) => {
       <Tooltip
         label={serverErrorMessage}
         fontSize="md"
-        isOpen={serverErrorMessage.length > 50 ? openTooltip : false}
+        isOpen={serverErrorMessage?.length > 50 ? openTooltip : false}
         color="#E45200"
       >
         <Box minHeight="19.5px">
@@ -233,7 +233,7 @@ const SendForm: React.FC<SendFormProps> = ({ goToStep }) => {
               onClick={handleOpenTooltip}
               onMouseEnter={handleOpenTooltip}
             >
-              {truncate(serverErrorMessage, 50)}
+            {serverErrorMessage ? truncate(serverErrorMessage, 50) : ""} :
             </Box>
           )}
         </Box>


### PR DESCRIPTION
Closes #69 

## Description
- [X] Sending page input amount changes 

Fixed by making sure handleAmount isn't an async function

- [X] CORS error on sending tx

I believe this may be fixed by https://github.com/UseKeyp/keyp-app/pull/331 because I was always getting a 502 error, even when I was testing with Postman (see photo below). So although the browser says it's a CORS error I'm hoping it's actually just a 502 error that's caused by the tokens endpoint crashing due to the .replace bug

- [X] Ramp widget, allow any asset on polygon network, not just usdc

Now specify onlyCryptoNetworks on the OnRamperWidget to restrict to Polygon

- SendForm.tsx was throwing errors in prod when serverErrorMessage was null so I added null checks

## Screenshots

Amount updates immediately now
 
https://github.com/UseKeyp/kaching-app/assets/47253537/14d56d46-d667-4656-9532-a789c72910f1

CORS error in prod is a 502 (bad gateway), which I believe is caused by the server crashing when /tokens is called

<img width="750" alt="cors error" src="https://github.com/UseKeyp/kaching-app/assets/47253537/37c9b00f-1feb-4779-9bf4-1202f23c48eb">

Any asset on Polygon now available

https://github.com/UseKeyp/kaching-app/assets/47253537/1f010d6e-aabc-448e-87b1-3da60a7c76e3

serverErrorMessage in prod

<img width="786" alt="serverErrorMessageprod" src="https://github.com/UseKeyp/kaching-app/assets/47253537/5519d5c9-4c0c-4da4-9de8-eeee9f5565e2">



